### PR TITLE
Merge in work to allow Topaz VEAI  filter support (#8)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,9 +2,26 @@
 
 # Option feature set to FALSE if not rewuired and TRUE if required
 ENABLE_FFPLAY=FALSE
+ENABLE_TOPAZ=TRUE
 
 # set true for dependant features, export those needed in ffmpeg build script
  
+if [[ "${ENABLE_TOPAZ}" == "TRUE" ]]
+then
+    export ENABLE_TOPAZ=TRUE
+    echo You have enabled Topaz Video AI support.
+    echo This execuatable can not be re-distributed under the terms of the GPL
+    echo and hence is for you private use only.
+    echo Using the Topaz Video AI filters requires an activate Topaz Video AI licence.
+    echo and install of the Application with the models you wish to use.
+    echo To use the Topaz Video AI filters you must set the environment variable VEAI_MODEL_DIR 
+    echo and log into Topaz using the login commanda
+    echo 
+    echo export VEAI_MODEL_DIR="/Applications/Topaz Video AI.app/Contents/Resources/models"
+    echo out/bin/login topaz_account_email_address topaz_account_password 
+
+fi
+
 if [[ "${ENABLE_FFPLAY}" == "TRUE" ]]
 then
     export ENABLE_FFPLAY=TRUE
@@ -173,7 +190,8 @@ echoDurationInSections $START_TIME
 
 START_TIME=$(currentTimeInSeconds)
 echoSection "compile openh264"
-$SCRIPT_DIR/build-openh264.sh "$SCRIPT_DIR" "$WORKING_DIR" "$TOOL_DIR" "$CPUS" "2.1.1" > "$WORKING_DIR/build-openh264.log" 2>&1
+#$SCRIPT_DIR/build-openh264.sh "$SCRIPT_DIR" "$WORKING_DIR" "$TOOL_DIR" "$CPUS" "2.1.1" > "$WORKING_DIR/build-openh264.log" 2>&1
+$SCRIPT_DIR/build-openh264.sh "$SCRIPT_DIR" "$WORKING_DIR" "$TOOL_DIR" "$CPUS" "2.3.0" > "$WORKING_DIR/build-openh264.log" 2>&1
 checkStatus $? "build openh264"
 echoDurationInSections $START_TIME
 
@@ -212,8 +230,15 @@ then
 fi
 
 START_TIME=$(currentTimeInSeconds)
+if [[ "${ENABLE_TOPAZ}" == "TRUE" ]]
+then
+echoSection "compile ffmpeg with topaz"
+$SCRIPT_DIR/build-ffmpeg-topaz.sh "$SCRIPT_DIR" "$WORKING_DIR" "$TOOL_DIR" "$OUT_DIR" "$CPUS" "5.1.0.24" > "$WORKING_DIR/build-ffmpeg-topaz.log" 2>&1
+else
 echoSection "compile ffmpeg"
 $SCRIPT_DIR/build-ffmpeg.sh "$SCRIPT_DIR" "$WORKING_DIR" "$TOOL_DIR" "$OUT_DIR" "$CPUS" "5.1" > "$WORKING_DIR/build-ffmpeg.log" 2>&1
+fi
+
 checkStatus $? "build ffmpeg"
 echoDurationInSections $START_TIME
 

--- a/build/build-ffmpeg-topaz.sh
+++ b/build/build-ffmpeg-topaz.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+# $1 = script directory
+# $2 = working directory
+# $3 = tool directory
+# $4 = output directory
+# $5 = CPUs
+# $6 = FFmpeg version
+
+# load functions
+. $1/functions.sh
+
+SOFTWARE=ffmpeg-topaz
+SOFT_PATH=${SOFTWARE}/FFmpeg-topaz-v${6}
+SOFT_REDIST_PATH=${SOFTWARE}/ffmpeg-redist-${6}
+
+make_directories() {
+
+  # start in working directory
+  cd "$2"
+  checkStatus $? "change directory failed"
+  mkdir ${SOFTWARE}
+  checkStatus $? "create directory failed"
+  cd ${SOFTWARE}
+  checkStatus $? "change directory failed"
+
+}
+
+download_code () {
+
+  cd "$2/${SOFTWARE}"
+  checkStatus $? "change directory failed"
+  # download source
+  curl -Lo topaz-ffmpeg.zip  https://github.com/TopazLabs/FFmpeg/archive/refs/tags/topaz-v${6}.zip
+  checkStatus $? "download of ${SOFTWARE} failed"
+
+  # unpack ffmpeg
+  unzip topaz-ffmpeg.zip
+  checkStatus $? "$3 Source extract failed"
+  
+  cd ../${SOFT_PATH} 
+  checkStatus $? "$3 Source directory failed"
+
+
+  cd ..
+  curl -Lo topaz-redist_ffmpeg.txz https://github.com/TopazLabs/FFmpeg/releases/download/topaz-v${6}/topaz-ffmpeg-redist-mac-${6}.txz
+  checkStatus $? "download of ${SOFTWARE} librariesfailed"
+
+  tar -xJf topaz-redist_ffmpeg.txz
+  checkStatus $? "$3 Redist extract failed"
+
+  cd ../${SOFT_REDIST_PATH} 
+  checkStatus $? "$3 Source directory failed"
+
+
+}
+
+configure_build () {
+
+  cd "$2/${SOFT_PATH}/"
+  checkStatus $? "change directory failed"
+
+  # prepare build
+  FF_FLAGS="-L${3}/lib -I${3}/include"
+  TOPAZ_FLAGS="-L${2}/${SOFT_REDIST_PATH}/lib -I${2}/${SOFT_REDIST_PATH}/include/videoai"
+  export LDFLAGS="${FF_FLAGS} ${TOPAZ_FLAGS}"
+  export CFLAGS="${FF_FLAGS} ${TOPAZ_FLAGS}"
+
+  FFMPEG_EXTRAS=''
+  
+  if [[ "${ENABLE_FFPLAY}" == "TRUE" ]]
+  then
+       FFMPEG_EXTRAS="${FFMPEG_EXTRAS} --enable-sdl2"
+  fi
+
+  TOPAZ_BREAKS='--enable-libopenh264'
+
+  # --pkg-config-flags="--static" is required to respect the Libs.private flags of the *.pc files
+  ./configure --prefix="$4" --enable-gpl --pkg-config-flags="--static"   --pkg-config=$3/bin/pkg-config \
+      --enable-libaom --enable-libx264 --enable-libx265 --enable-libvpx \
+      --enable-libmp3lame --enable-libopus --enable-neon --enable-runtime-cpudetect \
+      --enable-audiotoolbox --enable-videotoolbox --enable-libvorbis --enable-libsvtav1 \
+      --enable-libass  --enable-opencl ${FFMPEG_EXTRAS} --enable-veai 
+#      --enable-libass --enable-lto --enable-libopenh264 --enable-opencl ${FFMPEG_EXTRAS}
+
+  checkStatus $? "configuration of ${SOFTWARE} failed"
+
+}
+
+make_clean() {
+
+  cd "$2/${SOFT_PATH}/"
+  checkStatus $? "change directory failed"
+  make clean
+  checkStatus $? "make clean for $SOFTWARE failed"
+
+
+}
+
+make_compile () {
+
+  cd "$2/${SOFT_PATH}/"
+  checkStatus $? "change directory failed"
+
+  # build
+  make -j $5
+  checkStatus $? "build of ${SOFTWARE} failed"
+
+  # install
+  make install
+  checkStatus $? "installation of ${SOFTWARE} failed"
+  cp -r ${2}/${SOFT_REDIST_PATH}/Frameworks $4 
+  cp -r ${2}/${SOFT_REDIST_PATH}/bin $4 
+
+}
+
+build_main () {
+
+
+  # ffmpeg we always want to rebuild
+
+  if [[ ! -d "$2/${SOFTWARE}" ]]
+  then
+    make_directories $@
+    download_code $@
+    configure_build $@
+  fi
+
+  make_clean $@
+  make_compile $@
+
+}
+
+build_main $@

--- a/test/test.sh
+++ b/test/test.sh
@@ -49,12 +49,15 @@ $4/bin/ffmpeg -y -i "$2/test.mp4" -c:v "libaom-av1" -cpu-used 6 -row-mt 1 -an "$
 checkStatus $? "test aom av1"
 echoDurationInSections $START_TIME
 
+if [[ "${ENABLE_TOPAZ}" != "TRUE" ]]
+then
 # test openh264
 START_TIME=$(currentTimeInSeconds)
 echoSection "run test openh264 encoding"
 $4/bin/ffmpeg -y -i "$2/test.mp4" -c:v "libopenh264" -an "$3/test-openh264.mp4" > "$3/test-openh264.log" 2>&1
 checkStatus $? "test openh264"
 echoDurationInSections $START_TIME
+fi
 
 # test x264
 START_TIME=$(currentTimeInSeconds)


### PR DESCRIPTION
* Enable the ability to compile Topaz Video AI's filters. Note these are not statically linked.
Requires A licenced copy of Topaz Video AI.

* Missing file

* Update Topaz version of ffmepg to 5.1.0.24, this is the version in the release versoion of VEAI 3.0