### PR TITLE
Make temporary build artifact directories safely; ensure that pre-existing globally installed framework-style copies of OGG are deprioritized 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -95,10 +95,10 @@ export PKG_CONFIG_PATH=${TOOL_DIR}/lib/pkgconfig
 
 # prepare workspace
 echoSection "prepare workspace"
-mkdir "$TOOL_DIR"
+mkdir -p "$TOOL_DIR"
 checkStatusAndAction $? "unable to create tool directory"
 PATH="$TOOL_DIR/bin:$PATH"
-mkdir "$OUT_DIR"
+mkdir -p "$OUT_DIR"
 checkStatusAndAction $? "unable to create output directory"
 
 # detect CPU threads (nproc for linux, sysctl for osx)

--- a/build/build-vorbis.sh
+++ b/build/build-vorbis.sh
@@ -38,7 +38,7 @@ configure_build () {
   checkStatus $? "change directory failed"
 
   # prepare build
-  cmake -DCMAKE_INSTALL_PREFIX:PATH=$3 -DBUILD_SHARED_LIBS=OFF .
+  cmake -DCMAKE_INSTALL_PREFIX:PATH=$3 -DBUILD_SHARED_LIBS=OFF -DOGG_ROOT=$3 -DCMAKE_POLICY_DEFAULT_CMP0074=NEW -DCMAKE_POLICY_DEFAULT_CMP0144=NEW -DCMAKE_FIND_FRAMEWORK=LAST .
   checkStatus $? "configuration of ${SOFTWARE} failed"
 
 }


### PR DESCRIPTION
Without these changes, subsequent invokations of `build.sh` will automatically fail prematurely following intermediary failure encounters when triaging downstream bleeding edge compilation issues.

Additionally, there is a separate solution offered here in relation to how the Vorbis library's CMake setup resolves its dependency upon OGG. If the user has previously already installed a system-wide pre-compiled copy of OGG as a "Framework", then Vorbis's CMake scripts will incorrectly identify that root-level location as what to link against, rather than the repository clone's own recently built and locally stored OGG. This is amended with the `CMAKE_FIND_FRAMEWORK` argument inside of `build/build-vorbis.sh`. The other default policy value override arguments are technically redundant given the version of CMake that is used in your environment, but they are nonetheless included here for extra good measure.